### PR TITLE
Fix NullPointerException in simulateNullPointerException by Adding Null Check

### DIFF
--- a/app/src/main/java/com/example/errorapplication/MainActivity.java
+++ b/app/src/main/java/com/example/errorapplication/MainActivity.java
@@ -89,7 +89,7 @@ public class MainActivity extends AppCompatActivity {
     private void simulateNullPointerException() {
         try {
             String nullStr = null;
-            nullStr.length();
+            if (nullStr != null) { nullStr.length(); }
         } catch (NullPointerException e) {
             Log.e(TAG, getString(R.string.null_pointer_exception), e);
             writeErrorToFile(getString(R.string.null_pointer_exception), e);


### PR DESCRIPTION
This pull request addresses a NullPointerException that occurs in the simulateNullPointerException method. The exception was caused by attempting to call length() on a String object that could be null. To resolve this, a null check has been added before invoking the length() method. This prevents the exception and allows for proper handling of null String values. Alternatively, Objects.requireNonNull(str) can be used to fail fast with a clear message, but in this fix, a conditional check is implemented to handle the null case gracefully.

Please review and let me know if further changes are needed.