### PR TITLE
Fix NullPointerException in simulateNullPointerException by Adding Null Check

### DIFF
--- a/app/src/main/java/com/example/errorapplication/MainActivity.java
+++ b/app/src/main/java/com/example/errorapplication/MainActivity.java
@@ -89,7 +89,7 @@ public class MainActivity extends AppCompatActivity {
     private void simulateNullPointerException() {
         try {
             String nullStr = null;
-            nullStr.length();
+            if (nullStr != null) { nullStr.length(); }
         } catch (NullPointerException e) {
             Log.e(TAG, getString(R.string.null_pointer_exception), e);
             writeErrorToFile(getString(R.string.null_pointer_exception), e);


### PR DESCRIPTION
> Generated on 2025-06-23 09:03:05 UTC by unknown

## Issue
A `NullPointerException` was occurring in the `simulateNullPointerException` method. This happened when the code attempted to call the `length()` method on a `String` object that was `null`.

## Fix
Added a null check before calling the `length()` method on the `String` object to prevent the exception.

## Details
- Implemented a conditional check to verify that the `String` is not `null` before invoking `length()`.
- Optionally, considered using `Objects.requireNonNull()` to provide a clearer failure message if the `String` is unexpectedly `null`.

## Impact
- Prevents runtime crashes due to `NullPointerException` in the affected method.
- Improves the stability and reliability of the application by handling potential null values gracefully.

## Notes
- Future work could include adding more comprehensive null safety checks throughout the codebase.
- Consider implementing input validation or using annotations to enforce non-null contracts where appropriate.