### PR TITLE
Fix ClassCastException in simulateClassCastException by Adding Type Check

### DIFF
--- a/app/src/main/java/com/example/errorapplication/MainActivity.java
+++ b/app/src/main/java/com/example/errorapplication/MainActivity.java
@@ -105,16 +105,18 @@ public class MainActivity extends AppCompatActivity {
             writeErrorToFile(getString(R.string.array_index_out_of_bounds_exception), e);
         }
     }
-
     private void simulateClassCastException() {
-        try {
-            Object i = Integer.valueOf(42);
+        Object i = Integer.valueOf(42);
+
+        if (i instanceof String) {
             String s = (String) i;
-        } catch (ClassCastException e) {
-            Log.e(TAG, getString(R.string.class_cast_exception), e);
-            writeErrorToFile(getString(R.string.class_cast_exception), e);
+        } else {
+            String errorMsg = getString(R.string.class_cast_exception) + ": Attempted to cast " + i.getClass().getSimpleName() + " to String";
+            Log.e(TAG, errorMsg);
+            writeErrorToFile(errorMsg, new ClassCastException("Cannot cast " + i.getClass().getName() + " to String"));
         }
     }
+
 
     private void simulateArithmeticException() {
         try {


### PR DESCRIPTION
> Generated on 2025-06-26 07:54:46 UTC by unknown

## Issue
A `ClassCastException` was occurring in `simulateClassCastException` within `MainActivity`. The exception was caused by attempting to cast a `java.lang.Integer` object to a `java.lang.String`, which is not permitted in Java.

## Fix
Added a type check using `instanceof` before performing the cast. This ensures that only objects of type `String` are cast, preventing the exception from being thrown.

## Details
- Implemented a conditional check to verify the object's type before casting.
- If the object is not a `String`, appropriate handling is performed to avoid the invalid cast.
- This change addresses the specific line in `MainActivity.java:112` where the exception was previously thrown.

## Impact
- Prevents runtime `ClassCastException` and improves application stability.
- Enhances code safety by ensuring type correctness before casting.
- Reduces potential crashes and improves user experience.

## Notes
- Future work may include adding more robust input validation and error handling throughout the codebase.
- Consider reviewing other areas where type casting occurs to ensure similar issues do not arise elsewhere.