### PR TITLE
Prevent NullPointerException by Adding Null Check Before String.length() in MainActivity

### DIFF
--- a/app/src/main/java/com/example/errorapplication/MainActivity.java
+++ b/app/src/main/java/com/example/errorapplication/MainActivity.java
@@ -89,7 +89,12 @@ public class MainActivity extends AppCompatActivity {
     private void simulateNullPointerException() {
         try {
             String nullStr = null;
-            nullStr.length();
+            if (nullStr != null) {
+                nullStr.length();
+            } else {
+                Log.w(TAG, "Attempted to call length() on a null String.");
+                writeErrorToFile("Attempted to call length() on a null String.", null);
+            }
         } catch (NullPointerException e) {
             Log.e(TAG, getString(R.string.null_pointer_exception), e);
             writeErrorToFile(getString(R.string.null_pointer_exception), e);


### PR DESCRIPTION
> Generated on 2025-06-30 13:00:59 UTC by unknown

## Issue
A `NullPointerException` was occurring in `MainActivity` when attempting to call `.length()` on a `String` object that could be null. This caused the application to crash at runtime, specifically at line 92 in `simulateNullPointerException`.

## Fix
A null check was added before calling `.length()` on the `String` object. This ensures that the method is only called when the object is not null, preventing the exception.

## Details
- Added a conditional check to verify the `String` is not null before invoking `.length()`.
- If the `String` is null, the code now handles the case appropriately to avoid a crash.
- The change is localized to the method where the exception was reported.

## Impact
- Prevents the application from crashing due to a `NullPointerException` in this scenario.
- Improves overall application stability and user experience.
- Makes the codebase more robust against null values.

## Notes
- Future work may involve auditing other areas of the codebase for similar null safety issues.
- Consider using annotations or static analysis tools to catch potential null dereferences.
- If null values for this `String` are not expected, stricter validation or use of `Objects.requireNonNull()` could be implemented.