### PR TITLE
Fix NullPointerException in simulateNullPointerException by Adding Null Check

### DIFF
--- a/app/src/main/java/com/example/errorapplication/MainActivity.java
+++ b/app/src/main/java/com/example/errorapplication/MainActivity.java
@@ -21,6 +21,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.io.IOException;
+import android.util.Log;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -87,8 +88,13 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void simulateNullPointerException() {
-            String nullStr = null;
-            nullStr.length();
+        String nullStr = null;
+        if (nullStr == null) {
+            Log.e("MainActivity", "simulateNullPointerException: nullStr is null");
+            Toast.makeText(this, "Error: String is null", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        nullStr.length();
     }
 
     private void simulateArrayIndexOutOfBoundsException() {


### PR DESCRIPTION
> Generated on 2025-06-30 14:58:12 UTC by unknown

## Issue

**A NullPointerException was occurring in `simulateNullPointerException`** due to an attempt to call the `length()` method on a null `String` object. This caused the application to crash when the affected code path was triggered.

## Fix

**Added a null check before calling `length()` on the String object** in `simulateNullPointerException`. This prevents the exception by ensuring the method is only called on non-null objects.

## Details

- Introduced a conditional check to verify that the `String` is not null before invoking `length()`.
- If the `String` is null, the code now handles this case appropriately to avoid a crash.
- This change is localized to the `simulateNullPointerException` method in `MainActivity`.

## Impact

- **Prevents application crashes** caused by null `String` references in this method.
- Improves overall application stability and user experience.
- Makes the codebase more robust against similar null reference issues.

## Notes

- Future work may include auditing other areas of the codebase for similar null safety issues.
- Consider adopting more comprehensive null-safety practices or using annotations to prevent similar bugs.
- No changes were made to the logic beyond the null check; further enhancements may be considered if needed.