### PR TITLE
Fix NullPointerException When Accessing Null List in MainActivity

### DIFF
--- a/app/src/main/java/com/example/errorapplication/MainActivity.java
+++ b/app/src/main/java/com/example/errorapplication/MainActivity.java
@@ -82,11 +82,16 @@ public class MainActivity extends AppCompatActivity {
         Date now = new Date();
         return sdf.format(now);
     }
-
     private void simulateNullPointerException() {
         List<String> applicationStates = getApplicationScreen();
+        if (applicationStates == null || applicationStates.isEmpty()) {
+            Log.e("MainActivity", "simulateNullPointerException: applicationStates is null or empty");
+            Toast.makeText(this, "Application state is unavailable.", Toast.LENGTH_SHORT).show();
+            return;
+        }
         String domain = applicationStates.get(0);
     }
+
 
     private void simulateArrayIndexOutOfBoundsException() {
             String serverUrl = getServerUrl();


### PR DESCRIPTION
> Generated on 2025-07-02 11:39:10 UTC by unknown

## Issue
**A NullPointerException was occurring in `MainActivity` due to attempts to access methods on a `List` object that was not initialized.**  
This resulted in application crashes when the code tried to call `.get(int)` on a null reference.

## Fix
**Added checks to ensure the `List` is initialized before accessing its methods.**  
The code now verifies that the `List` is not null and the index is valid before attempting to retrieve items.

## Details
- Added null checks for the `List` object before any method calls.
- Implemented index bounds checking to prevent out-of-bounds access.
- Updated affected logic in `MainActivity` to handle cases where the `List` is null or empty.

## Impact
- Prevents application crashes caused by null `List` references.
- Improves application stability and user experience.
- Ensures safer handling of collections throughout the affected code.

## Notes
- Further review may be needed to audit other areas where similar null checks should be implemented.
- Consider implementing utility methods or adopting best practices for null safety in future development.